### PR TITLE
[documentação] Adiciona descrição às queries de velocidades do brt

### DIFF
--- a/views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_carro.sql
+++ b/views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_carro.sql
@@ -1,7 +1,45 @@
+/*
+
+SQL Flavor: Standard SQL
+
+Propósito:
+  Calcula as velocidades médias de cada carro, identificado por 'placa', para os quais estejamos capturando posições válidas.
+*/
+/*
+wrows:
+  ST_GEOGPOINT é usado em 'latitude'/'longitude' por conveniência no cálculo das distâncias usando funções geográficas disponíveis ao BigQuery.
+  Então criamos o campo 'point' com os valores de lat/long para cada linha. ROW_NUMBER() é usado para indexar cada linha dentro da agregação e permitir, 
+  nos próximos passos, o cálculo das distâncias entre pontos sucessivos ordenados por 'timestamp_captura', esses indíces são salvos no campo 'n_rows'
+*/
 WITH wrows AS (
   SELECT ST_GEOGPOINT(longitude, latitude) point, timestamp_captura, timestamp_gps, latitude, longitude, placa,
         ROW_NUMBER() OVER (PARTITION BY placa ORDER BY timestamp_captura) n_row
-  from `rj-smtr.dashboard_monitoramento_brt.registros_filtrada`),  
+  from `rj-smtr.dashboard_monitoramento_brt.registros_filtrada`),
+/*
+distances:
+  Neste passo calculamos a diferença de tempo ('minutos') e a distância entre dois pontos capturados consecutivamente. Para isso, nos valemos da indexação
+  do passo anterior e realizamos uma junção da tabela (t1) com ela mesma, porém com todas as colunas deslocadas por 1 com relação ao índice, condição
+  explicitada na cláusula JOIN ... ON t1.n_row = t2.n_row - 1.
+    Ex:
+    t1
+      point   timestamp_captura   timestamp_gps         latitude  longitude placa    n_row 
+    1 (x1,y1) 2021-07-27T00:05:00 2021-07-27T00:04:50   x1         y1       AAA0000   1
+    2 (x2,y2) 2021-07-27T00:06:00 2021-07-27T00:05:40   x2         y2       AAA0000   2
+    3 (x3,y3) 2021-07-27T00:07:00 2021-07-27T00:06:47   x3         y3       AAA0000   3
+    
+    t2
+      point   timestamp_captura   timestamp_gps         latitude  longitude placa    n_row 
+    1 (x1,y1) 2021-07-27T00:05:00 2021-07-27T00:04:50   x1         y1       AAA0000   1
+    2 (x2,y2) 2021-07-27T00:06:00 2021-07-27T00:05:40   x2         y2       AAA0000   2
+    3 (x3,y3) 2021-07-27T00:07:00 2021-07-27T00:06:47   x3         y3       AAA0000   3
+
+    distances
+      ts1                   ts2                   latitude    longitude     placa   minutos   distancia  
+    1 2021-07-27T00:05:00   null                  x1           y1           AA000   null      null
+    2 2021-07-27T00:06:00   2021-07-27T00:05:00   x2           y2           AA0000  ts2-ts1   ST_DISTANCE((x2,y2) - (x1,y1))
+    3 2021-07-27T00:07:00   2021-07-27T00:06:00   x3           y3           AA0000  ts2-ts1   ST_DISTANCE((x3,y3) - (x2,y2))
+*/  
+
 distances AS (
   SELECT
     t1.timestamp_captura ts1, 
@@ -14,6 +52,19 @@ distances AS (
   ON t1.n_row = t2.n_row -1
   AND t1.placa = t2.placa
   ),
+/*
+times:
+  Neste passo, criamos uma tabela vazia com as faixas de 10 minutos, as quais popularemos com as velocidades médias calculadas por faixa.
+  Fazemos isso, selecionando a data mínima e máxima presente no dado base (`rj-smtr.dashboard_monitoramento_brt.registros_filtrada`) e utilizando
+  GENERATE_TIMESTAMP_ARRAY para gerar todas as timestamps para os intervalos de 10 minutos compreendidos entre as datas máxima e mínima.
+    Ex:
+    times
+      min_date              max_date              ts
+    1 2021-07-27T00:00:00   2021-07-28T00:00:00   2021-07-27T00:10:00
+    2 2021-07-27T00:00:00   2021-07-28T00:00:00   2021-07-27T00:20:00
+    3 2021-07-27T00:00:00   2021-07-28T00:00:00   2021-07-27T00:30:00
+    ...
+*/
 times AS (
   SELECT ts
   FROM (
@@ -22,6 +73,17 @@ times AS (
     FROM `rj-smtr.dashboard_monitoramento_brt.registros_filtrada`) t 
   JOIN UNNEST(GENERATE_TIMESTAMP_ARRAY(t.min_date, t.max_date, INTERVAL 10 MINUTE)) ts
 ),
+/*
+speed:
+  Aqui, a tabela é uma junção simples dos timestamps gerados em times ('ts') com as colunas de distances. Esse é passo de popular a tabela vazia mencionado
+  acima. Essa tabela terá os campos 'ts' (de times), 'ts1' e 'ts2' (de distances), assim para a junção usamos a seguinte condição:
+    ts2 não ser menor que ts: como ts2 é o ponto futuro para cálculo da velocidade, não podemos tê-lo menor que o valor de 'ts' que inicia um intervalo de
+    10 minutos.
+    ts1 não pode ser maior que ts + 10 min: como ts1 é o ponto inicial para calculo da velocidade, essa condição impede que peguemos valores de ts1 na próxima
+    faixa de 10 minutos.
+  Quando satisfazemos as condições, teremos diversos pares 'ts1', 'ts2' associados ao mesmo 'ts', permitindo que agrupemos por 'ts' e calculemos as médias de
+  velocidade com esse agrupamento.
+*/
 speed AS (
   SELECT
     ts,
@@ -32,6 +94,14 @@ speed AS (
       ts2 < DATETIME(ts) OR 
       ts1 > DATETIME_ADD(DATETIME(ts), INTERVAL 10 MINUTE))
  )
+/*
+Finalmente, podemos calcular as velocidades. Selecionamos 'ts2' como valor para 'timestamp_captura' pois só em 'ts2' não nulo teremos valores não nulos para
+a 'distancia' e 'minutos' (em speed). Neste passo, fazemos a junção de speed com uma subconsulta à própria speed. A subconsulta na cláusula JOIN é usada para
+calcular as velocidades médias (AVG(SAFE_DIVIDE(distancia,minutos)), o fator 6/100 é uma conversão de unidades para km/h) agregando por placa (para usar 
+somente dados de carros individuais) e por 'ts', que define as faixas de 10 minutos nas quais a velocidade média será avaliada. 
+No resultado final, calculamos novamente a média das velocidades dadas na subconsulta, porém agora agregado em 'ts2' e com junção nas faixas horárias('ts') e
+nas placas.
+*/
 SELECT
   ts2 as timestamp_captura, t1.placa, latitude, longitude, AVG(t1.velocidade) velocidade
 FROM speed

--- a/views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_status.sql
+++ b/views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_status.sql
@@ -1,4 +1,10 @@
 WITH paradas as (
+  /*
+  paradas:
+    Tabela contendo os dados geográficos (lat/lon) para todas as estações e garagens que temos cadastradas para o BRT, cujas tabelas base são as presentes 
+    nas cláusulas FROM.
+    A tabela em si é apenas uma união de todas as garagens e estações que estejam cadastradas como ativas (cláusula 'where ativa = 1')
+  */
   select
     ST_GEOGPOINT(longitude, latitude) ponto_parada, nome_estacao nome_parada, 'estacao' tipo_parada
   from `rj-smtr.br_rj_riodejaneiro_transporte.estacoes_e_terminais_brt` t1
@@ -8,11 +14,24 @@ WITH paradas as (
   from `rj-smtr.br_rj_riodejaneiro_transporte.garagens` t2
   where ativa = 1),
 onibus_parados AS (
+  /*
+  onibus_parados:
+    Neste passo, onibus parados é uma tabela que somente apresenta os dados para cada carro e suas respectivas velocidades médias, calculadas sobre faixas
+    horárias de 10 minutos e com o novo campo 'ponto_carro', criado a partir de ST_GEOGPOINT() por conveniência para o cálculo das distâncias entre pontos
+    geográficos.
+  */
   select
     *, ST_GEOGPOINT(longitude, latitude) ponto_carro
   from `rj-smtr.dashboard_monitoramento_brt.velocidade_carro` 
   ),
 distancia AS (
+  /*
+  distancia:
+    Nesta tabela selecionamos os campos com dados relativos a cada carro e calculamos sua distância com relação à parada mais próxima e indexamos os 
+    resultados dentro de cada partição (cláusula PARTITION BY) ordenando pela distância da parada e salvamos o índice em 'n_row'.
+    A ordenação dos indíces em ordem crescente de distância da parada, nos permitirá selecionar somente a menor distância (relativa à parada mais próxima) no
+    próximo passo. Além disso, a junção da tabela paradas com onibus_parados se dá onde 1=1 (?????????????)
+  */
   SELECT 
     timestamp_captura, velocidade, placa, longitude, latitude, nome_parada, tipo_parada,
     ST_DISTANCE(ponto_carro, ponto_parada) distancia_parada, 
@@ -21,6 +40,18 @@ distancia AS (
   join onibus_parados o
   on 1=1
   )
+  /*
+  Por fim, selecionamos todos os campos exceto 'n_row' de distancia e criamos os novos campos 'status_movimento' e 'status_tipo_parada'.
+    status_movimento:
+      Campo criado condicionalmente (cláusula CASE) que discrimina os carros em duas categorias, "parado" quando a velocidade na faixa horária avaliada é
+      menor que 3 km/h e "andando", caso contrário.
+    status_tipo_parada:
+      Outro campo criado condicionalmente que discrimina as paradas consideradas de acordo com a distância do carro em questão à parada sendo considerada.
+      Caso o carro esteja a menos de 1000m da parada, consideramos o tipo da parada cadastrado em 'tipo_parada' de paradas, caso contrário, consideramos a 
+      parada como "não identificado"
+  O filtro aplicado ao fim (clausula WHERE) faz com que peguemos apenas a menor distância do carro à uma parada, dado que, em distancia, calculamos a 
+    distância do carro à todas as paradas, usamos 'n_row = 1' pois a coluna está em ordenação crescente das distâncias até as paradas.
+  */
 SELECT
   * except(nrow),
   case


### PR DESCRIPTION
Descrição breve:
Documenta as queries `br_rj_riodejaneiro_brt_gps.aux_registros_velocidade_carro` e `br_rj_riodejaneiro_brt_gps.aux_registros_velocidade_status` com descrições comentadas para cada passo/ subquery da análise.

Changelog:
- views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_carro.sql
- views/br_rj_riodejaneiro_brt_gps/aux_registros_velocidade_status.sql