### PR TITLE
[BRT] add aux_registros_intersec and realized_trips 

### DIFF
--- a/smtr/br_rj_riodejaneiro_brt_gps/aux_registros_intersec.sql
+++ b/smtr/br_rj_riodejaneiro_brt_gps/aux_registros_intersec.sql
@@ -1,0 +1,58 @@
+/*View para calcular quais linhas tem alguma correspondência com as trajetórias capturas dos veículos em circulação*/
+with shapes as (
+/*
+GEOGRAPHY type geometry for shapes
+*/
+select *
+from `rj-smtr-dev.br_rj_riodejaneiro_sigmob.shapes_geom` -- Apontar para a tabela a ser criada em prod
+),
+registros as (
+/*
+Generate ponto_carro for GEOGRAPHY operations
+*/
+select *, ST_GEOGPOINT(longitude, latitude) ponto_carro
+from `rj-smtr-dev.pytest.brt_registros_tratada_1_dia` -- Apontar para a tabela base a ser definida 
+),
+times as (
+/*
+Generate empty table of intervals
+*/
+select faixa_horaria 
+from (
+select CAST(MIN(data) as TIMESTAMP) min_date, TIMESTAMP_ADD(CAST(MAX(data) as TIMESTAMP), interval 1 day) max_date
+from registros ) r
+join UNNEST(GENERATE_TIMESTAMP_ARRAY(r.min_date, r.max_date, Interval 5 minute)) faixa_horaria
+),
+faixas as (
+/*
+Join registros with intervals generated above
+*/
+select codigo, linha, timestamp_captura, faixa_horaria, longitude, latitude, ponto_carro, data, hora
+from times t
+join registros r
+on (r.timestamp_captura between datetime(faixa_horaria) and datetime(timestamp_add(faixa_horaria, interval 5 minute)))
+),
+intersects as (
+/*
+Count number of intersects between vehicle and informed route shape
+*/
+select codigo as vehicle_id, 
+       f.linha as linha_gps,
+       s.linha_gtfs,
+       shape_distance as distance,
+       data, hora, faixa_horaria, s.shape_id as trip_id,
+       min(timestamp_captura) as timestamp_inicio,
+       count(timestamp_captura) as total_count,
+       count(case when st_dwithin(ponto_carro, shape, 100) then 1 end) n_intersec,
+       case
+           when count(case when st_dwithin(start_pt, ponto_carro, 100) is true then 1 end)>=1 then 'start'
+           when count(case when st_dwithin(end_pt, ponto_carro, 100) is true then 1 end)>=1 then 'end'
+           else 'middle' end as status
+from faixas f
+join shapes s
+on 1=1
+group by codigo, faixa_horaria, linha_gps, linha_gtfs, trip_id, data, hora, distance
+)
+select * from intersects
+where n_intersec>0 
+order by vehicle_id, trip_id, faixa_horaria, n_intersec

--- a/smtr/br_rj_riodejaneiro_brt_gps/realized_trips.sql
+++ b/smtr/br_rj_riodejaneiro_brt_gps/realized_trips.sql
@@ -1,0 +1,53 @@
+with 
+t as (
+    -- Aggregate status to detect start and end of trip
+    select vehicle_id,linha_gps,linha_gtfs, round(distance,1) distance, trip_id, faixa_horaria, status,
+        string_agg(status,"") over (
+            partition by vehicle_id, trip_id
+            order by vehicle_id, trip_id, faixa_horaria
+            rows between current row and 1 following) = 'startmiddle' starts,
+        string_agg(status,"") over (
+            partition by vehicle_id, trip_id
+            order by vehicle_id, trip_id, faixa_horaria
+            rows between 1 preceding and current row) = 'middleend' ends
+    from `rj-smtr-dev.br_rj_riodejaneiro_brt_gps.aux_registros_linha_intersec_no_buffer` -- Apontar para a tabela correta
+    where linha_gps = linha_gtfs
+    order by trip_id, faixa_horaria),
+s as (
+    -- Get start and end times for trips based on the previous aggregation
+    select *,
+        case when
+        string_agg(status,"") over (
+            partition by vehicle_id, trip_id
+            order by vehicle_id, trip_id, faixa_horaria
+            rows between current row and 1 following) = 'startend' 
+        then datetime(faixa_horaria, "America/Sao_Paulo") end departure_time,
+        case when string_agg(status,"") over (
+            partition by vehicle_id, trip_id
+            order by vehicle_id, trip_id, faixa_horaria
+            rows between 1 preceding and current row) = 'startend' 
+        then datetime(faixa_horaria,"America/Sao_Paulo") end arrival_time
+    from t
+    where starts = true or ends = true),
+w as (
+    -- Lags arrival_time (fetching from preceding row) to properly match trip times
+    select vehicle_id,linha_gps, linha_gtfs, distance, trip_id, 
+        lag(departure_time) over(
+        partition by vehicle_id, trip_id 
+        order by vehicle_id, trip_id, faixa_horaria) departure_time,
+        arrival_time,
+    from s),
+realized_trips as (
+    -- Define trajectory_type (1 = 'complete trip'), calculates elapsed_time and average speed over the whole trip
+    select *,
+        1 as trajectory_type,
+        datetime_diff(arrival_time, departure_time, minute) as elapsed_time, 
+        round(SAFE_DIVIDE(distance/1000, datetime_diff(arrival_time, departure_time, minute)/60), 1) as average_speed
+    from w
+    where departure_time is not null
+    order by vehicle_id, linha_gtfs, trip_id, departure_time)
+
+--Filter bulk data by speed, to cut off outlying results
+select * 
+from realized_trips 
+where average_speed between 10 and 90


### PR DESCRIPTION
Descrição breve:

Adiciona queries para calcular todas as linhas cujos trajetos apresentam alguma correspondência com as trajetórias percorridas pelos carros (`aux_registros_intersec`) e para calcular as viagens realizadas por cada carro (`realized_trips)`.

- aux_registros_intersec:
  A partir dos registros já filtrados/tratados e dos dados de `shapes` para cada linha planejada, calculamos a cada 5 minutos o número de vezes que o ponto informado pelos dados de gps esteve dentro do traçado determinado.  Usamos o mesmo método para medir se o carro começou ou terminou uma viagem dentro da faixa horária de 5 minutos considerada (resultados contidos na coluna status).
- realized_trips:
   A partir das intersecções calculadas, usamos o `status` agregado por carro, itinerário e ordenado por faixa horária para encontrar o início/fim de cada viagem e contabilizar como viagem realizada somente aquelas que têm em seu histórico pelo menos um status "start" e um "end"

Changelog:
 - smtr/br_rj_riodejaneiro_brt_gps/aux_registros_intersec.sql
 - smtr/br_rj_riodejaneiro_brt_gps/realized_trips.sql