### PR TITLE
[SIGMOB] Adiciona nova versão para data_versao_efetiva

### DIFF
--- a/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
@@ -1,10 +1,152 @@
+with
+agency as (
 SELECT 
     data,
     data_versao as data_versao_original, 
-    CASE WHEN data < '{{data_inicio_sigmob_historico}}' THEN '{{data_inicio_sigmob_historico}}' ELSE
-        LAST_VALUE(data_versao IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    CASE WHEN data < DATE("{{ data_inclusao_agency }}") THEN DATE("{{ data_inclusao_agency }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
     END AS data_versao_efetiva
 FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
 LEFT JOIN (SELECT DISTINCT data_versao
-    FROM rj-smtr-dev.br_rj_riodejaneiro_sigmob.shapes_geom)
+    FROM {{ agency }})
+ON data = DATE(data_versao)
+),
+calendar as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data <= DATE("{{ data_inclusao_calendar }}") THEN DATE("{{ data_inclusao_calendar }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ calendar }})
+ON data = DATE(data_versao)
+),
+frota_determinada as (
+SELECT 
+    data,
+    DATE(data_versao) as data_versao_original, 
+    CASE WHEN data <= DATE("{{ data_inclusao_frota_determinada }}") THEN DATE("{{ data_inclusao_frota_determinada }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ frota_determinada }})
+ON DATE(data) = DATE(data_versao)
+),
+linhas as (
+  SELECT 
+    data,
+    DATE(data_versao) as data_versao_original, 
+    CASE WHEN data < DATE("{{ data_inclusao_linhas }}") THEN DATE("{{ data_inclusao_linhas }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ linhas }})
+ON data = DATE(data_versao)
+),
+routes as (
+SELECT 
+    data,
+    DATE(data_versao) as data_versao_original, 
+   CASE WHEN data < DATE("{{ data_inclusao_routes }}") THEN DATE("{{ data_inclusao_routes }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ routes }})
 ON data = data_versao
+),
+shapes as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+   CASE WHEN data < DATE("{{ data_inclusao_shapes }}") THEN DATE("{{ data_inclusao_shapes }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ shapes }})
+ON data = DATE(data_versao)
+),
+stop_details as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data <= DATE("{{ data_inclusao_stop_details }}") THEN DATE("{{ data_inclusao_stop_details }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ stop_details }})
+ON data = DATE(data_versao)
+),
+stop_times as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data < DATE("{{ data_inclusao_stop_times }}") THEN DATE("{{ data_inclusao_stop_times }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ stop_times }})
+ON data = DATE(data_versao)
+),
+stops as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data < DATE("{{ data_inclusao_stops }}") THEN DATE("{{ data_inclusao_stops }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ stops }})
+ON data = DATE(data_versao)
+),
+trips as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data < DATE"{{ data_inclusao_trips }}" THEN DATE("{{ data_inclusao_trips }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY('2020-01-01', CURRENT_DATE())) data
+LEFT JOIN (SELECT DISTINCT data_versao
+    FROM {{ trips }})
+ON data = DATE(data_versao)
+)
+select
+s.data,
+a.data_versao_efetiva as data_versao_efetiva_agency,
+c.data_versao_efetiva as data_versao_efetiva_calendar,
+f.data_versao_efetiva as data_versao_efetiva_frota_determinada,
+l.data_versao_efetiva as data_versao_efetiva_linhas,
+r.data_versao_efetiva as data_versao_efetiva_routes,
+s.data_versao_efetiva as data_versao_efetiva_shapes,
+sd.data_versao_efetiva as data_versao_efetiva_stop_details,
+st.data_versao_efetiva as data_versao_efetiva_stop_times,
+sp.data_versao_efetiva as data_versao_efetiva_stops,
+t.data_versao_efetiva as data_versao_efetiva_trips
+from shapes s 
+join agency a
+on s.data = a.data
+join calendar c
+on s.data = c.data
+join frota_determinada f
+on s.data = f.data
+join linhas l
+on s.data = l.data
+join routes r
+on s.data = r.data
+join stops sp
+on s.data = sp.data
+join stop_details sd
+on s.data = sd.data
+join stop_times st
+on s.data = st.data
+join trips t
+on s.data = t.data

--- a/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
@@ -48,16 +48,30 @@ partitioning:
 
 # Parâmetros da query
 parameters:
-  trips: "rj-smtr.br_rj_riodejaneiro_sigmob.trips"
+  agency: "rj-smtr.br_rj_riodejaneiro_sigmob.agency"
+  calendar: "rj-smtr.br_rj_riodejaneiro_sigmob.calendar"
+  frota_determinada: "rj-smtr.br_rj_riodejaneiro_sigmob.frota_determinada"
+  linhas: "rj-smtr.br_rj_riodejaneiro_sigmob.linhas"
   routes: "rj-smtr.br_rj_riodejaneiro_sigmob.routes"
   shapes: "rj-smtr.br_rj_riodejaneiro_sigmob.shapes"
-  stops: "rj-smtr.br_rj_riodejaneiro_sigmob.stops"
+  stop_times: "rj-smtr.br_rj_riodejaneiro_sigmob.stop_times"
   stop_details: "rj-smtr.br_rj_riodejaneiro_sigmob.stop_details"
+  stops: "rj-smtr.br_rj_riodejaneiro_sigmob.stops"
+  trips: "rj-smtr.br_rj_riodejaneiro_sigmob.trips"
 
   # Data de início do sigmob
   ## Todos os dados anteriores a esta data serão comparados com ela
   ## Dados posteriores serão comparados por dia.
-  data_inicio_sigmob_historico: "2021-08-24"
+  data_inclusao_agency: "2021-08-03"
+  data_inclusao_stop_times: "2021-08-03"
+  data_inclusao_linhas: "2021-08-03"
+  data_inclusao_routes: "2021-08-03"
+  data_inclusao_trips: "2021-08-03"
+  data_inclusao_shapes: "2021-08-24"
+  data_inclusao_stops: "2021-08-24"
+  data_inclusao_calendar: "2021-09-27"
+  data_inclusao_frota_determinada: "2021-09-27"
+  data_inclusao_stop_details: "2021-09-27"
 
 # Parâmetros de backfill
 backfill:


### PR DESCRIPTION
Descrição breve:
Nova tabela de data_versao_efetiva para os dados do SIGMOB. Uma tabela única que apresenta a data_versao a ser utilizada para cada um dos endpoints capturados.
A tabela apresenta a coluna `data` e as colunas `data_versao_efetiva_*`, cujo sufixo indica o endpoint/tabela à qual a `data_versao` se refere

Changelog:
- smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
- smtr/br_rj_riodejaneiro_sigmob/defaults.yaml: novos parâmetros para a data de inclusão de cada endpoint na pipeline de capturas
