### PR TITLE
[SIGMOB] Adiciona tabelas desaninhadas faltantes

### DIFF
--- a/smtr/br_rj_riodejaneiro_sigmob/agency_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/agency_desaninhada.sql
@@ -1,0 +1,9 @@
+SELECT
+  agency_id,
+  JSON_VALUE(content, "$.agency_name") agency_name,
+  JSON_VALUE(content, "$.agency_url") agency_url,
+  JSON_VALUE(content, "$.agency_timezone") agency_timezone,
+  JSON_VALUE(content, "$.agency_lang") agency_lang,
+  JSON_VALUE(content, "$.agency_phone") agency_phone,
+  DATE(data_versao) data_versao
+FROM {{ agency }}

--- a/smtr/br_rj_riodejaneiro_sigmob/calendar_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/calendar_desaninhada.sql
@@ -1,0 +1,14 @@
+SELECT
+  service_id,
+  JSON_VALUE(content, "$.monday") monday,
+  JSON_VALUE(content, "$.tuesday") tuesday,
+  JSON_VALUE(content, "$.wednesday") wednesday,
+  JSON_VALUE(content, "$.thursday") thursday,
+  JSON_VALUE(content, "$.friday") friday,
+  JSON_VALUE(content, "$.saturday") saturday,
+  JSON_VALUE(content, "$.sunday") sunday,
+  JSON_VALUE(content, "$.start_date") start_date,
+  JSON_VALUE(content, "$.end_date") end_date,
+  DATE(data_versao) data_versao
+
+FROM {{ calendar }}

--- a/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
@@ -4,28 +4,42 @@
 # - materialized: true|false para materializar ou não
 # - depends_on: lista de views das quais ela depende
 views:
-  shapes_geom:
-    materialized: true
-    depends_on: [br_rj_riodejaneiro_sigmob.shapes]
-  stops_desaninhada:
+  agency_desaninhada:
     materialized: false
-    depends_on: [br_rj_riodejaneiro_sigmob.stops]
-  stop_details_desaninhada:
+    depends_on: [br_rj_riodejaneiro_sigmob.agency]
+  calendar_desaninhada:
     materialized: false
-    depends_on: [br_rj_riodejaneiro_sigmob.stop_details]
-  agg_stops_vistoriadas:
+    depends_on: [br_rj_riodejaneiro_sigmob.calendar]
+  linhas_desaninhada:
     materialized: false
-    depends_on: [br_rj_riodejaneiro_sigmob.stops]
-  routes_desaninhada:
-    materialized: false
-    depends_on: [br_rj_riodejaneiro_sigmob.routes]
-  data_versao_efetiva:
-    materialized: false
-    depends_on: [br_rj_riodejaneiro_sigmob.routes]
+    depends_on: [br_rj_riodejaneiro_sigmob.linhas]
   frota_determinada_desaninhada:
     materialized: false
     depends_on: [br_rj_riodejaneiro_sigmob.frota_determinada]
-
+  routes_desaninhada:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.routes]
+  shapes_geom:
+    materialized: true
+    depends_on: [br_rj_riodejaneiro_sigmob.shapes]
+  stop_details_desaninhada:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.stop_details]
+  stop_times_desaninhada:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.stop_times]
+  stops_desaninhada:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.stops]
+  trips_desaninhada:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.trips]
+  agg_stops_vistoriadas:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.stops]
+  data_versao_efetiva:
+    materialized: false
+    depends_on: [br_rj_riodejaneiro_sigmob.routes]
 
 # Definição de taxa de atualização
 scheduling:
@@ -48,20 +62,32 @@ partitioning:
 
 # Parâmetros da query
 parameters:
-  trips: "rj-smtr.br_rj_riodejaneiro_sigmob.trips"
+  agency: "rj-smtr.br_rj_riodejaneiro_sigmob.agency"
+  calendar: "rj-smtr.br_rj_riodejaneiro_sigmob.calendar"
+  frota_determinada: "rj-smtr.br_rj_riodejaneiro_sigmob.frota_determinada"
+  linhas: "rj-smtr.br_rj_riodejaneiro_sigmob.linhas"
   routes: "rj-smtr.br_rj_riodejaneiro_sigmob.routes"
   shapes: "rj-smtr.br_rj_riodejaneiro_sigmob.shapes"
-  stops: "rj-smtr.br_rj_riodejaneiro_sigmob.stops"
+  stop_times: "rj-smtr.br_rj_riodejaneiro_sigmob.stop_times"
   stop_details: "rj-smtr.br_rj_riodejaneiro_sigmob.stop_details"
+  stops: "rj-smtr.br_rj_riodejaneiro_sigmob.stops"
+  trips: "rj-smtr.br_rj_riodejaneiro_sigmob.trips"
 
   # Data de início do sigmob
   ## Todos os dados anteriores a esta data serão comparados com ela
   ## Dados posteriores serão comparados por dia.
-  data_inicio_sigmob_historico: "2021-08-24"
+  data_inclusao_agency: "2021-08-03"
+  data_inclusao_stop_times: "2021-08-03"
+  data_inclusao_linhas: "2021-08-03"
+  data_inclusao_routes: "2021-08-03"
+  data_inclusao_trips: "2021-08-03"
+  data_inclusao_shapes: "2021-08-24"
+  data_inclusao_stops: "2021-08-24"
+  data_inclusao_calendar: "2021-09-30"
+  data_inclusao_frota_determinada: "2021-09-30"
+  data_inclusao_stop_details: "2021-09-30"
 
 # Parâmetros de backfill
 backfill:
   # Formato %Y-%m-%d %H:%M:%S
   start_timestamp: "2021-08-24 00:00:00"
-  interval:
-    days: 30

--- a/smtr/br_rj_riodejaneiro_sigmob/linhas_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/linhas_desaninhada.sql
@@ -1,0 +1,18 @@
+SELECT
+  linha_id,
+  JSON_VALUE(content, "$.agency_id") agency_id,
+  JSON_VALUE(content, "$.sigla") sigla,
+  JSON_VALUE(content, "$.idModalSmtr") id_modal_smtr,
+  JSON_VALUE(content, "$.TipoLinha") tipo_linha,
+  JSON_VALUE(content, "$.NomeLinha") nome_linha,
+  JSON_VALUE(content, "$.SiglaCompleta") sigla_completa,
+  JSON_VALUE(content, "$.NumeroServicos") numero_servicos,
+  JSON_VALUE(content, "$.ativa") ativa,
+  JSON_VALUE(content, "$.FrotaDeterminada") frota_determinada,
+  JSON_VALUE(content, "$.LegisFrotaDeterminada") legis_frota_determinada,
+  JSON_VALUE(content, "$.FrotaOperante") frota_operante,
+  JSON_VALUE(content, "$.id") id,
+  JSON_VALUE(content, "$.Apresentacao") apresentacao,
+  JSON_VALUE(content, "$.agency_name") agency_name,
+  DATE(data_versao) data_versao
+FROM {{ linhas }}

--- a/smtr/br_rj_riodejaneiro_sigmob/stop_times_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/stop_times_desaninhada.sql
@@ -1,0 +1,9 @@
+SELECT
+  stop_id,
+  JSON_VALUE(content, "$.trip_id") trip_id,
+  JSON_VALUE(content, "$.arrival_time") arrival_time,
+  JSON_VALUE(content, "$.departure_time") departure_time,
+  JSON_VALUE(content, "$.stop_sequence") stop_sequence,
+  JSON_VALUE(content, "$.shape_dist_traveled") shape_dist_traveled,
+  DATE(data_versao) data_versao
+FROM {{ stop_times }}

--- a/smtr/br_rj_riodejaneiro_sigmob/trips_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/trips_desaninhada.sql
@@ -1,0 +1,21 @@
+select
+  trip_id,
+  json_value(content, "$.route_id") route_id,
+  json_value(content, "$.service_id") service_id,
+  json_value(content, "$.trip_headsign") trip_headsign,
+  json_value(content, "$.trip_short_name") trip_short_name,
+  json_value(content, "$.direction_id") direction_id,
+  json_value(content, "$.block_id") block_id,
+  json_value(content, "$.shape_id") shape_id,
+  json_value(content, "$.variacao_itinerario") variacao_itinerario,
+  json_value(content, "$.versao") versao,
+  json_value(content, "$.complemento") complemento,
+  json_value(content, "$.via") via,
+  json_value(content, "$.observacoes") observacoes,
+  json_value(content, "$.ultima_medicao_operante") ultima_medicao_operante,
+  json_value(content, "$.idModalSmtr") id_modal_smtr,
+  json_value(content, "$.Direcao") direcao,
+  json_value(content, "$.id") id,
+  DATE(data_versao) data_versao
+
+from {{ trips }}


### PR DESCRIPTION
Descrição breve:
Adiciona versão desaninhada para as tabelas que ainda não tinham uma versão desaninhada no BigQuery

Changelog:
- smtr/br_rj_riodejaneiro_sigmob/agency_desaninhada.sql
- smtr/br_rj_riodejaneiro_sigmob/calendar_desaninhada.sql
- smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
- smtr/br_rj_riodejaneiro_sigmob/linhas_desaninhada.sql
- smtr/br_rj_riodejaneiro_sigmob/stop_times_desaninhada.sql
- smtr/br_rj_riodejaneiro_sigmob/trips_desaninhada.sql