### PR TITLE
[gps_sppo] Adiciona filtragem extra para a materialização

### DIFF
--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
@@ -22,7 +22,8 @@ gps AS (
   FROM
     {{ registros }}
   WHERE
-    data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+    data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
+    AND timestamp_gps BETWEEN {{ date_range_start }} AND {{ date_range_end }}
     AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     ),
 filtrada AS (

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
@@ -5,7 +5,6 @@ Filtragem e tratamento básico de registros de gps.
 2. Filtra registros antigos. Remove registros que tem diferença maior que 1 minuto entre o timestamp_captura e timestamp_gps.
 3. Muda o nome de variáveis para o padrão do projeto.
 	- id_veiculo --> ordem
-	- hora_completa
 */
 WITH
 box AS (
@@ -37,7 +36,7 @@ filtrada AS (
     linha,
     timestamp_gps,
     timestamp_captura,
-    DATA,
+    data,
     hora,
     row_number() over (partition by ordem, timestamp_gps, linha) rn
   FROM

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
@@ -23,7 +23,7 @@ gps AS (
     {{ registros }}
   WHERE
     data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
-    AND timestamp_gps BETWEEN {{ date_range_start }} AND {{ date_range_end }}
+    AND timestamp_gps > {{ date_range_start }} AND timestamp_gps <= {{ date_range_end }}
     AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
     ),
 filtrada AS (

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
@@ -22,7 +22,7 @@ WITH
       {{ registros_filtrada }} r 
     WHERE
       data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
-      and timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+      and timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
   ),
   intersec AS (
     SELECT

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
@@ -22,7 +22,7 @@ WITH
       {{ registros_filtrada }} r 
     WHERE
       data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
-      timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+      and timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   ),
   intersec AS (
     SELECT

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
@@ -49,7 +49,9 @@ WITH
       CASE WHEN s.linha_gtfs IS NULL THEN False ELSE True END AS flag_linha_existe_sigmob,
     -- 4. Join com data_versao_efetiva para definição de quais shapes serão considerados no cálculo das flags
     FROM (
-      SELECT t1.*, t2.data_versao_efetiva
+      SELECT 
+        t1.*,
+        t2.data_versao_efetiva_shapes as data_versao_efetiva
       FROM registros t1
       JOIN  {{ data_versao_efetiva }} t2
       ON t1.data = t2.data

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
@@ -22,6 +22,7 @@ WITH
       {{ registros_filtrada }} r 
     WHERE
       data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+      timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   ),
   intersec AS (
     SELECT

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
@@ -93,7 +93,9 @@ intersects AS (
 		AS status
 	-- 5. Junção com data_versao_efetiva
 	FROM (
-		SELECT t1.*, t2.data_versao_efetiva
+		SELECT 
+			t1.*,
+			t2.data_versao_efetiva_shapes as data_versao_efetiva
 		FROM faixas t1
 		JOIN  {{ data_versao_efetiva }} t2
 		ON t1.data = t2.data) f

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
@@ -22,7 +22,7 @@ registros as (
     WHERE
 		data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
     AND
-		timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+		timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
 ),
 times AS ( 
 	-- 1. Geração das faixas horárias

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
@@ -20,7 +20,9 @@ registros as (
 	SELECT *
 	FROM {{	 registros_filtrada }}
     WHERE
-        data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+		data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+    AND
+		timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
 ),
 times AS ( 
 	-- 1. Geração das faixas horárias

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
@@ -48,7 +48,7 @@ WITH
       WHERE
         data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
       AND
-        timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+        timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
       ) r
     on 1=1
   )

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
@@ -47,6 +47,8 @@ WITH
         {{ registros_filtrada }}
       WHERE
         data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+      AND
+        timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
       ) r
     on 1=1
   )

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
@@ -59,7 +59,7 @@ SELECT
   linha,
   /*
   3. e 4. Identificamos o status do veículo como 'terminal', 'garagem' (para os veículos parados) ou 
-  'nao_identificado' (para os veículos mais distantes de uma parada que o limiar definido)
+  null (para os veículos mais distantes de uma parada que o limiar definido)
   */
   case
     when distancia_parada < {{ distancia_limiar_parada }} then tipo_parada

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
@@ -72,7 +72,7 @@ SELECT
     linha, 
     distancia,
     ROUND(
-        CASE WHEN velocidade_media < {{ velocidade_maxima }}
+        CASE WHEN velocidade_media > {{ velocidade_maxima }}
             THEN {{ velocidade_maxima }}
             ELSE velocidade_media 
         END, 

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
@@ -47,6 +47,8 @@ with
     FROM  {{ registros_filtrada }}
     WHERE
         data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
+    AND
+        timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
     ),
     medias as (
         select 

--- a/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
@@ -48,7 +48,7 @@ with
     WHERE
         data between DATE({{ date_range_start }}) and DATE({{ date_range_end }})
     AND
-        timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+        timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
     ),
     medias as (
         select 

--- a/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
@@ -1,6 +1,6 @@
 # Definição de taxa de atualização
 scheduling:
-  cron: "0 0 * * *"
+  cron: "0 * * * *"
 
 # Definição de particionamento
 # - column: nome da coluna

--- a/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
@@ -64,8 +64,6 @@ parameters:
   shapes: "rj-smtr.br_rj_riodejaneiro_sigmob.shapes_geom" # flag_trajeto_correto, aux_registros_intersec
   data_versao_efetiva: "rj-smtr.br_rj_riodejaneiro_sigmob.data_versao_efetiva" # aux_registros_intersec, aux_registros_flag_trajeto_correto
   intersec: "rj-smtr.br_rj_riodejaneiro_onibus_gps.aux_registros_intersec" # viagens_realizadas
-  gps_sppo: "rj-smtr.br_rj_riodejaneiro_veiculos.gps_sppo" # registros_agg_*
-  linhas_sppo: "rj-smtr.br_rj_riodejaneiro_transporte.linhas_sppo" # registros_agg_data_hora_consorcio
 
 # Lista de views do dataset
 # Atributos de cada view:

--- a/smtr/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/smtr/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -26,6 +26,7 @@ WITH
 
     FROM {{ sppo_registros_filtrada }}
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
+    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   ),
   velocidades AS (
     -- 2. velocidades
@@ -34,6 +35,7 @@ WITH
     FROM
       {{ sppo_velocidade }} 
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
+    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   ),
   paradas as (
     -- 3. paradas
@@ -41,6 +43,7 @@ WITH
       id_veiculo, timestamp_gps, linha, tipo_parada,
     FROM {{ sppo_parada }}
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
+    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   ),
   flags AS (
     -- 4. flag_trajeto_correto
@@ -54,7 +57,8 @@ WITH
       flag_trajeto_correto_hist
     FROM
       {{ sppo_flag_trajeto_correto }}
-    WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})  
+    WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
+    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
   )
 -- 5. Junção final
 SELECT

--- a/smtr/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/smtr/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -26,7 +26,7 @@ WITH
 
     FROM {{ sppo_registros_filtrada }}
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
-    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+    AND timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
   ),
   velocidades AS (
     -- 2. velocidades
@@ -35,7 +35,7 @@ WITH
     FROM
       {{ sppo_velocidade }} 
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
-    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+    AND timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
   ),
   paradas as (
     -- 3. paradas
@@ -43,7 +43,7 @@ WITH
       id_veiculo, timestamp_gps, linha, tipo_parada,
     FROM {{ sppo_parada }}
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
-    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+    AND timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
   ),
   flags AS (
     -- 4. flag_trajeto_correto
@@ -58,7 +58,7 @@ WITH
     FROM
       {{ sppo_flag_trajeto_correto }}
     WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
-    AND timestamp_gps between {{ date_range_start }} and {{ date_range_end }}
+    AND timestamp_gps > {{ date_range_start }} and timestamp_gps <= {{ date_range_end }}
   )
 -- 5. Junção final
 SELECT


### PR DESCRIPTION
Issue relacionado: #7 

Descrição breve:
Adiciona um passo de filtragem além da filtragem básica por data já implementada nas versões atuais das queries.
O filtro se vale do formato dos parâmetros `date_range_start` e `date_range_end`, em formato _datetime_/_timestamp_, para que só sejam inseridas linhas da última hora no processo de materialização hora a hora. 

- Depende da tabela `data_versao_efetiva`


Changelog:
-  smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_filtrada.sql
-  smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_flag_trajeto_correto.sql
- smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_intersec.sql
- smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_parada.sql
- smtr/br_rj_riodejaneiro_onibus_gps/aux_registros_velocidade.sql
- smtr/br_rj_riodejaneiro_veiculos/gps_sppo.sql