### PR TITLE
[projeto_multa_automatica] Integracao STU

### DIFF
--- a/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
+++ b/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
@@ -28,7 +28,7 @@ sumario AS (
       replace(faixa_horaria, ":", "")
     ) as data_infracao
   FROM {{ sumario_multa_linha_onibus }}
-  WHERE DATE(data) = CURRENT_DATE()
+  WHERE DATE(data) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
 )
 
 SELECT

--- a/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
+++ b/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
@@ -30,6 +30,7 @@ sumario AS (
       " ",
       replace(faixa_horaria, ":", "")
     ) as data_infracao,
+    s.data,
     data_versao_efetiva
   FROM {{ sumario_multa_linha_onibus }} s
   JOIN (
@@ -48,7 +49,8 @@ SELECT
   ordem,
   s.linha,
   codigo_infracao,
-  data_infracao
+  data_infracao,
+  s.data
 FROM sumario s
 JOIN consorcios c
 ON s.linha=c.linha

--- a/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
+++ b/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
@@ -1,20 +1,23 @@
 WITH
 consorcios as (
   SELECT 
-    l.consorcio,
+    r.consorcio,
     codigo as permissao,
-    linha,  
+    linha,
+    data_versao  
   FROM (
-    select * 
-    from {{ linhas_sppo }}
-    WHERE servico = 'REGULAR') l
+    select 
+      agency_name consorcio,
+      route_short_name linha,
+      data_versao
+    from {{ routes }}) r
   join (
     select
       codigo,
       consorcio
     from {{ codigos_consorcios }} 
   ) c
-  on Normalize_and_Casefold(l.consorcio) = Normalize_and_Casefold(c.consorcio)
+  on Normalize_and_Casefold(r.consorcio) = Normalize_and_Casefold(c.consorcio)
 ),
 sumario AS (
   SELECT
@@ -23,17 +26,30 @@ sumario AS (
     linha,
     artigo_multa as codigo_infracao,
     concat(
-      replace(cast(data as string), "-", ""),
+      replace(cast(s.data as string), "-", ""),
       " ",
       replace(faixa_horaria, ":", "")
-    ) as data_infracao
-  FROM {{ sumario_multa_linha_onibus }}
-  WHERE DATE(data) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+    ) as data_infracao,
+    data_versao_efetiva
+  FROM {{ sumario_multa_linha_onibus }} s
+  JOIN (
+    select 
+      data, 
+      data_versao_efetiva_routes data_versao_efetiva
+    from {{ data_versao_efetiva }}
+  ) d
+  on s.data = d.data
+  where prioridade = 1
 )
 
 SELECT
   permissao,
-  s.*
+  placa,
+  ordem,
+  s.linha,
+  codigo_infracao,
+  data_infracao
 FROM sumario s
 JOIN consorcios c
 ON s.linha=c.linha
+and s.data_versao_efetiva = c.data_versao


### PR DESCRIPTION
Descrição:
Refatoração simples da tabela `projeto_multa_automatica.view_sumario_multa_integrado_stu`. As mudanças implementadas são as seguintes:
- Remove o filtro de data https://github.com/RJ-SMTR/maestro-bq/blob/e86408550202518395d09f97e91edd7710bcd271/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql#L31 para que possamos parametrizar a data de execução ao subir o `.csv` para a GCS
- Remove a dependência com a base obsoleta `br_rj_riodejaneiro_transporte.linhas_sppo` em favor do uso de `br_rj_riodejaneiro_sigmob.routes_desaninhada`. A dependência com a tabela `codigos_consorcio` ainda não pode ser desfeita, visto que esse código é o campo `permissão` necessário à integração com o STU.

Changelog:
- smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql