### PR TITLE
[SIGMOB] Altera o campo de filtragem para a stops_desaninhada

### DIFF
--- a/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
@@ -44,7 +44,7 @@ SELECT
     json_value(content, '$.Vista') as Vista,
     json_value(content, '$.Horarios') as Horarios,
     json_value(content, '$.id') as id,
-    json_value(content, '$.Inexistente') as Inexistente
+    json_value(content, '$.PontoExistente') as PontoExistente
 FROM {{ stops }} t
 where data_versao = (select max(data_versao) FROM {{ stops }})
 and json_value(content, '$.PontoExistente') = 'SIM'

--- a/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
@@ -47,5 +47,5 @@ SELECT
     json_value(content, '$.Inexistente') as Inexistente
 FROM {{ stops }} t
 where data_versao = (select max(data_versao) FROM {{ stops }})
-and json_value(content, '$.Inexistente') = 'SIM'
+and json_value(content, '$.PontoExistente') = 'SIM'
 and json_value(content, '$.idModalSmtr') = '22'


### PR DESCRIPTION
Descrição:
Com a mudança do campo `Inexistente` para `PontoExistente`, o filtro aplicado ao fim da `stops_desaninhada` quebrou, com a consulta retornando vazia por apontar sempre para a última `data_versao` capturada. Aqui está a alteração necessária.


Changelog:
- smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql