### PR TITLE
[SIGMOB] [projeto_multa_automatica] Adiciona tabela de feriados

### DIFF
--- a/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
@@ -44,6 +44,21 @@ LEFT JOIN (
     )
 ON DATE(data) = DATE(data_versao)
 ),
+holidays as (
+SELECT 
+    data,
+    data_versao as data_versao_original, 
+    CASE WHEN data < DATE"{{ data_inclusao_holidays }}" THEN DATE("{{ data_inclusao_holidays }}") ELSE
+        LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
+    END AS data_versao_efetiva
+FROM UNNEST(GENERATE_DATE_ARRAY(DATE('2021-01-01'), CURRENT_DATE())) data
+LEFT JOIN (
+    SELECT DISTINCT data_versao
+    FROM {{ holidays }}
+    WHERE DATE(data_versao) BETWEEN DATE_SUB(DATE({{ date_range_start }}), INTERVAL 7 DAY) AND DATE({{ date_range_end }})
+    )
+ON data = DATE(data_versao)
+),
 linhas as (
     SELECT 
     data,
@@ -138,7 +153,7 @@ trips as (
 SELECT 
     data,
     data_versao as data_versao_original, 
-    CASE WHEN data < DATE"{{ data_inclusao_trips }}" THEN DATE("{{ data_inclusao_trips }}") ELSE
+    CASE WHEN data < DATE("{{ data_inclusao_trips }}") THEN DATE("{{ data_inclusao_trips }}") ELSE
         LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
     END AS data_versao_efetiva
 FROM UNNEST(GENERATE_DATE_ARRAY(DATE('2021-01-01'), CURRENT_DATE())) data
@@ -155,6 +170,7 @@ joined as (
     a.data_versao_efetiva as data_versao_efetiva_agency,
     c.data_versao_efetiva as data_versao_efetiva_calendar,
     f.data_versao_efetiva as data_versao_efetiva_frota_determinada,
+    h.data_versao_efetiva as data_versao_efetiva_holidays,
     l.data_versao_efetiva as data_versao_efetiva_linhas,
     r.data_versao_efetiva as data_versao_efetiva_routes,
     s.data_versao_efetiva as data_versao_efetiva_shapes,
@@ -169,6 +185,8 @@ joined as (
     on a.data = c.data
     join frota_determinada f
     on a.data = f.data
+    join holidays h
+    on a.data = h.data
     join linhas l
     on a.data = l.data
     join routes r

--- a/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql
@@ -48,7 +48,7 @@ holidays as (
 SELECT 
     data,
     data_versao as data_versao_original, 
-    CASE WHEN data < DATE"{{ data_inclusao_holidays }}" THEN DATE("{{ data_inclusao_holidays }}") ELSE
+    CASE WHEN data <= DATE("{{ data_inclusao_holidays }}") THEN DATE("{{ data_inclusao_holidays }}") ELSE
         LAST_VALUE(DATE(data_versao) IGNORE NULLS) OVER (ORDER BY data ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) 
     END AS data_versao_efetiva
 FROM UNNEST(GENERATE_DATE_ARRAY(DATE('2021-01-01'), CURRENT_DATE())) data

--- a/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
@@ -65,6 +65,7 @@ parameters:
   agency: "rj-smtr.br_rj_riodejaneiro_sigmob.agency"
   calendar: "rj-smtr.br_rj_riodejaneiro_sigmob.calendar"
   frota_determinada: "rj-smtr.br_rj_riodejaneiro_sigmob.frota_determinada"
+  holidays: "rj-smtr.br_rj_riodejaneiro_sigmob.holidays"
   linhas: "rj-smtr.br_rj_riodejaneiro_sigmob.linhas"
   routes: "rj-smtr.br_rj_riodejaneiro_sigmob.routes"
   shapes: "rj-smtr.br_rj_riodejaneiro_sigmob.shapes"
@@ -87,6 +88,7 @@ parameters:
   data_inclusao_calendar: "2021-09-30"
   data_inclusao_frota_determinada: "2021-09-30"
   data_inclusao_stop_details: "2021-09-30"
+  data_inclusao_holidays: "2021-11-02"
 
 # Parâmetros de backfill
 backfill:

--- a/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_sigmob/defaults.yaml
@@ -88,7 +88,7 @@ parameters:
   data_inclusao_calendar: "2021-09-30"
   data_inclusao_frota_determinada: "2021-09-30"
   data_inclusao_stop_details: "2021-09-30"
-  data_inclusao_holidays: "2021-11-02"
+  data_inclusao_holidays: "2021-11-05"
 
 # Parâmetros de backfill
 backfill:

--- a/smtr/projeto_multa_automatica/defaults.yaml
+++ b/smtr/projeto_multa_automatica/defaults.yaml
@@ -115,6 +115,7 @@ parameters:
   proporcao_dia_util: 0.8
   proporcao_sabado: 0.5
   proporcao_domingo: 0.4
+  proporcao_feriado: 0.4
 
   ## Multa de faixas horárias não consecutivas
   multa_nao_consecutiva:

--- a/smtr/projeto_multa_automatica/defaults.yaml
+++ b/smtr/projeto_multa_automatica/defaults.yaml
@@ -158,6 +158,7 @@ parameters:
   sumario_multa_linha_onibus: rj-smtr.projeto_multa_automatica.sumario_multa_linha_onibus
   data_versao_efetiva: rj-smtr.br_rj_riodejaneiro_sigmob.data_versao_efetiva
   frota_determinada: rj-smtr.br_rj_riodejaneiro_sigmob.frota_determinada_desaninhada
+  holidays: rj-smtr.br_rj_riodejaneiro_sigmob.holidays
   routes: rj-smtr.br_rj_riodejaneiro_sigmob.routes_desaninhada
   agency: rj-smtr.br_rj_riodejaneiro_sigmob.agency
   linhas_sppo: rj-smtr.br_rj_riodejaneiro_transporte.linhas_sppo

--- a/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
@@ -214,7 +214,7 @@ select
     case 
         when frota_servico <= {{ limiar_frota_determinada }} then frota_servico -- até 5 carros 
         when tipo_dia = 'Domingo' then  floor(frota_servico * {{ proporcao_domingo }}) -- domingo
-        when tipo_dia = 'Feriado' then  floor(frota_servico * {{ proporcao_domingo }}) -- feriados
+        when tipo_dia = 'Feriado' then  floor(frota_servico * {{ proporcao_feriado }}) -- feriados
         when tipo_dia = 'Sabado' then  floor(frota_servico * {{ proporcao_sabado }}) -- sábado
         else floor(frota_servico * {{ proporcao_dia_util }}) -- dias úteis
     end frota_minima,
@@ -222,7 +222,7 @@ select
     case 
         when frota_servico <= {{ limiar_frota_determinada }} and frota_servico > frota_aferida then true -- até 5 carros 
         when tipo_dia = 'Domingo' and  floor(frota_servico * {{ proporcao_domingo }}) > frota_aferida then true -- domingo
-        when tipo_dia = 'Feriado' and  floor(frota_servico * {{ proporcao_domingo }}) > frota_aferida then true -- feriados
+        when tipo_dia = 'Feriado' and  floor(frota_servico * {{ proporcao_feriado }}) > frota_aferida then true -- feriados
         when tipo_dia = 'Sabado' and  floor(frota_servico * {{ proporcao_sabado }}) > frota_aferida then true -- sábado
         when floor(frota_servico * {{ proporcao_dia_util }}) > frota_aferida then true  -- dias úteis
         else false

--- a/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
@@ -198,7 +198,7 @@ frota_consorcio as (
             WHEN extract(dayofweek from data) = 1 THEN 'Domingo'
             WHEN extract(dayofweek from data) = 7 THEN 'Sabado'
             WHEN data = data_feriado THEN 'Feriado'
-            ELSE 'Dia Util'
+            ELSE 'Dia Útil'
         END tipo_dia
     FROM 
         frotas_combinadas f1

--- a/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
@@ -70,12 +70,25 @@ capturas_por_faixa_horaria as (
 frota_sigmob as (
     -- 5. 
     select 
-        d.data,
+        f.data,
+        data_feriado,
         DATE(f.data_versao) data_versao,
         route_short_name,
         sum(FrotaServico) frota_servico,
         consorcio
-    from {{ frota_determinada }} f
+    from (
+        select * 
+        from {{ frota_determinada }} f1
+        join (
+            select
+                data,
+                data_versao_efetiva_agency,
+                data_versao_efetiva_frota_determinada,
+                data_versao_efetiva_holidays,
+                data_versao_efetiva_routes,
+            from {{ data_versao_efetiva }}) d
+    on 
+        DATE(f1.data_versao) = d.data_versao_efetiva_frota_determinada) f
     join (
         select  
             route_id, 
@@ -87,7 +100,7 @@ frota_sigmob as (
     on 
         f.route_id = r.route_id
     and 
-        DATE(f.data_versao) = r.data_versao
+        DATE(f.data_versao_efetiva_routes) = r.data_versao
     join (
         select 
             agency_id,
@@ -98,18 +111,23 @@ frota_sigmob as (
     on
         r.agency_id = c.agency_id
     and
-        r.data_versao = c.data_versao
-    join {{ data_versao_efetiva }} d
-    on 
-        d.data_versao_efetiva_agency = c.data_versao
-        and d.data_versao_efetiva_routes = r.data_versao
-        and d.data_versao_efetiva_frota_determinada = DATE(f.data_versao)
+        f.data_versao_efetiva_agency = c.data_versao
+    left join (
+        select 
+            data as data_feriado,
+            data_versao
+        from {{ holidays }}
+        ) h
+    on
+        f.data_versao_efetiva_holidays = DATE(h.data_versao)
+        and f.data = h.data_feriado
     group by 
-        d.data, f.data_versao, route_short_name, consorcio
+        f.data, data_feriado, f.data_versao, route_short_name, consorcio
 ),
 sigmob_combinacoes as (
     select 
         data,
+        data_feriado,
         data_versao,
         route_short_name,
         frota_servico,
@@ -129,6 +147,7 @@ sigmob_combinacoes as (
 frotas_combinadas as (
     SELECT
         f2.data,
+        f2.data_feriado,
         f2.route_short_name as linha,
         f2.faixa_horaria,
         coalesce(f1.frota_aferida,0) frota_aferida,
@@ -174,28 +193,37 @@ frota_consorcio as (
                 ELSE 'fora pico'
             END
             {% endfor %}
-        END pico
+        END pico,
+        CASE
+            WHEN extract(dayofweek from data) = 1 THEN 'Domingo'
+            WHEN extract(dayofweek from data) = 7 THEN 'Sabado'
+            WHEN data = data_feriado THEN 'Feriado'
+            ELSE 'Dia Util'
+        END tipo_dia
     FROM 
         frotas_combinadas f1
 )
 select 
     t1.linha,
     t1.data data,
+    tipo_dia,
     cast(t1.faixa_horaria as string) faixa_horaria,
     pico,
     frota_aferida,
     frota_servico,
     case 
         when frota_servico <= {{ limiar_frota_determinada }} then frota_servico -- até 5 carros 
-        when extract(dayofweek from t1.data) = 1 then  floor(frota_servico * {{ proporcao_domingo }}) -- domingo
-        when extract(dayofweek from t1.data) = 7 then  floor(frota_servico * {{ proporcao_sabado }}) -- sábado
+        when tipo_dia = 'Domingo' then  floor(frota_servico * {{ proporcao_domingo }}) -- domingo
+        when tipo_dia = 'Feriado' then  floor(frota_servico * {{ proporcao_domingo }}) -- feriados
+        when tipo_dia = 'Sabado' then  floor(frota_servico * {{ proporcao_sabado }}) -- sábado
         else floor(frota_servico * {{ proporcao_dia_util }}) -- dias úteis
     end frota_minima,
     SAFE_DIVIDE(frota_aferida, frota_servico) porcentagem_frota,
     case 
         when frota_servico <= {{ limiar_frota_determinada }} and frota_servico > frota_aferida then true -- até 5 carros 
-        when extract(dayofweek from t1.data) = 1 and  floor(frota_servico * {{ proporcao_domingo }}) > frota_aferida then true -- domingo
-        when extract(dayofweek from t1.data) = 7 and  floor(frota_servico * {{ proporcao_sabado }}) > frota_aferida then true -- sábado
+        when tipo_dia = 'Domingo' and  floor(frota_servico * {{ proporcao_domingo }}) > frota_aferida then true -- domingo
+        when tipo_dia = 'Feriado' and  floor(frota_servico * {{ proporcao_domingo }}) > frota_aferida then true -- feriados
+        when tipo_dia = 'Sabado' and  floor(frota_servico * {{ proporcao_sabado }}) > frota_aferida then true -- sábado
         when floor(frota_servico * {{ proporcao_dia_util }}) > frota_aferida then true  -- dias úteis
         else false
     end flag_irregular,

--- a/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_linha_onibus_completa.sql
@@ -158,7 +158,7 @@ frotas_combinadas as (
             t1.*,
             t2.data_versao_efetiva_frota_determinada as data_versao_efetiva
         FROM frota_completa t1
-        JOIN rj-smtr.br_rj_riodejaneiro_sigmob.data_versao_efetiva t2
+        JOIN {{ data_versao_efetiva }} t2
         on t1.data = t2.data
     ) f1
     right join 

--- a/smtr/projeto_multa_automatica/detalhes_multa_linha_onibus.sql
+++ b/smtr/projeto_multa_automatica/detalhes_multa_linha_onibus.sql
@@ -80,6 +80,7 @@ select
     concat(replace(cast(data as string), '-', ''), '-', linha, '-', pico,'-', prioridade) id_multa,
     linha,
     data,
+    tipo_dia,
     pico,
     faixa_horaria,
     frota_aferida,

--- a/smtr/projeto_multa_automatica/detalhes_multa_linha_onibus.sql
+++ b/smtr/projeto_multa_automatica/detalhes_multa_linha_onibus.sql
@@ -21,7 +21,7 @@ multa_nao_consecutiva as (
     countif(flag_irregular) over (
         partition by linha, data, pico, flag_irregular
         order by linha, data, pico, faixa_horaria
-    rows between unbounded preceding and unbounded following) >= {{ multa_nao_consecutiva["valor"] }} flag_multa,
+    rows between unbounded preceding and current row) >= {{ multa_nao_consecutiva["valor"] }} flag_multa,
     "{{ multa_nao_consecutiva["descricao"] }}" tipo_multa,
     "{{ multa_nao_consecutiva["artigo"] }}" artigo_multa,
     {{ multa_nao_consecutiva["prioridade"] }} prioridade 

--- a/smtr/projeto_multa_automatica/detalhes_veiculo_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_veiculo_onibus_completa.sql
@@ -4,8 +4,6 @@
  operação/garagem) 
 */
 
-with 
-gps as (
 select distinct
     data,
     servico as linha,
@@ -23,30 +21,3 @@ from {{ gps_sppo }}
 WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
 and timestamp_gps > {{ date_range_start }} 
 and timestamp_gps <= {{ date_range_end }}
-),
-efetiva as (
-select 
-    g.*, 
-    data_versao_efetiva
-from gps g
-join (
-    select 
-        data,
-        data_versao_efetiva_holidays as data_versao_efetiva
-  from {{ data_versao_efetiva }}
-  ) d
-  on g.data = d.data
-),
-holidays as (
-select 
-    array_agg(data) as feriados, 
-    data_versao 
-from {{ holidays }}
-group by data_versao
-)
-select 
-    e.* except(data_versao_efetiva)
-from efetiva e
-join holidays f
-on e.data_versao_efetiva = date(f.data_versao)
-where e.data not in unnest(f.feriados)

--- a/smtr/projeto_multa_automatica/detalhes_veiculo_onibus_completa.sql
+++ b/smtr/projeto_multa_automatica/detalhes_veiculo_onibus_completa.sql
@@ -4,6 +4,8 @@
  operação/garagem) 
 */
 
+with 
+gps as (
 select distinct
     data,
     servico as linha,
@@ -21,3 +23,30 @@ from {{ gps_sppo }}
 WHERE data BETWEEN DATE({{ date_range_start }}) AND DATE({{ date_range_end }})
 and timestamp_gps > {{ date_range_start }} 
 and timestamp_gps <= {{ date_range_end }}
+),
+efetiva as (
+select 
+    g.*, 
+    data_versao_efetiva
+from gps g
+join (
+    select 
+        data,
+        data_versao_efetiva_holidays as data_versao_efetiva
+  from {{ data_versao_efetiva }}
+  ) d
+  on g.data = d.data
+),
+holidays as (
+select 
+    array_agg(data) as feriados, 
+    data_versao 
+from {{ holidays }}
+group by data_versao
+)
+select 
+    e.* except(data_versao_efetiva)
+from efetiva e
+join holidays f
+on e.data_versao_efetiva = date(f.data_versao)
+where e.data not in unnest(f.feriados)

--- a/smtr/projeto_multa_automatica/sumario_multa_linha_onibus.sql
+++ b/smtr/projeto_multa_automatica/sumario_multa_linha_onibus.sql
@@ -33,11 +33,7 @@ select
     t2.vista,
     t2.consorcio,
     t1.data,
-    case extract(dayofweek from date(data))
-        when 1 then 'Domingo'
-        when 7 then 'Sábado'
-        else 'Dia Útil' 
-    end tipo_dia,
+    t1.tipo_dia,
     pico,
     faixa_horaria,
     t1.frota_servico,

--- a/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
+++ b/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
@@ -36,7 +36,9 @@ sumario AS (
     from {{ data_versao_efetiva }}
   ) d
   on s.data = d.data
-  where prioridade = 1
+  where 
+    prioridade = 1
+    and tipo_dia = 'Dia Util'
 )
 
 SELECT

--- a/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
+++ b/smtr/projeto_multa_automatica/view_sumario_multa_integrado_stu.sql
@@ -38,7 +38,7 @@ sumario AS (
   on s.data = d.data
   where 
     prioridade = 1
-    and tipo_dia = 'Dia Util'
+    and tipo_dia = 'Dia Útil'
 )
 
 SELECT


### PR DESCRIPTION
Descrição:
- Adiciona o campo `data_versao_efetiva_holidays` à `br_rj_riodejaneiro_sigmob.data_versao_efetiva` para lidar com possíveis buracos nas capturas do SIGMOB. 
- Adiciona a filtragem de feriados à `projeto_multa_automatica.detalhes_veiculo_onibus_completa`, de modo que o dado base para as outras tabelas já não contará os dias de feriado.

**Obs**:  depende da aprovação do [PR 159](https://github.com/RJ-SMTR/maestro/pull/159) no maestro para criação da tabela holidays em prod.

Changelog:
- smtr/br_rj_riodejaneiro_sigmob/data_versao_efetiva.sql: adiciona campo `data_versao_efetica_holidays`
- smtr/br_rj_riodejaneiro_sigmob/defaults.yaml: adiciona parametros para `holidays` (data_inclusao_holidays e nome completo da tabela)
- smtr/projeto_multa_automatica/defaults.yaml: adiciona `holidays` como parâmetro
- smtr/projeto_multa_automatica/detalhes_veiculo_onibus_completa.sql: adiciona filtragem de feriados