### PR TITLE
[SIGMOB] Adequação à alteração de id's

### DIFF
--- a/smtr/br_rj_riodejaneiro_brt_gps/aux_registros_flag_trajeto_correto.sql
+++ b/smtr/br_rj_riodejaneiro_brt_gps/aux_registros_flag_trajeto_correto.sql
@@ -56,7 +56,7 @@ WITH
     LEFT JOIN (
       SELECT * 
       FROM {{ shapes }} 
-      WHERE id_modal_smtr = "{{ id_modal_smtr }}"
+      WHERE id_modal_smtr in ({{ id_modal_smtr|join(', ') }})
     ) s
     ON
       r.linha = s.linha_gtfs

--- a/smtr/br_rj_riodejaneiro_brt_gps/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_brt_gps/defaults.yaml
@@ -1,6 +1,6 @@
 # Definição de taxa de atualização
 scheduling:
-  cron: "0 * * * *"
+  cron: "*/5 * * * *"
 # Parâmetros de backfill
 backfill:
   # Formato %Y-%m-%d %H:%M:%S
@@ -27,7 +27,7 @@ partitioning:
 parameters:
   # IdModalSMTR
   # 20 -> BRT
-  id_modal_smtr: "20"
+  id_modal_smtr: ["'20'", "'B'"]
 
   # Filtro de velocidade no cálculo de viagens realizadas
   ## Serão consideradas somente velocidades entre os valores abaixo

--- a/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
+++ b/smtr/br_rj_riodejaneiro_onibus_gps/defaults.yaml
@@ -29,7 +29,7 @@ parameters:
   # IdModalSMTR
   # 22 -> SPPO
   # 23 -> SPPO Executivo
-  id_modal_smtr: ["'22'", "'23'"]
+  id_modal_smtr: ["'22'", "'23'", "'O'"]
 
   # Filtro de velocidade no cálculo de viagens realizadas
   ## Serão consideradas somente velocidades entre os valores abaixo

--- a/smtr/br_rj_riodejaneiro_sigmob/agg_stops_vistoriadas.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/agg_stops_vistoriadas.sql
@@ -7,7 +7,8 @@ SELECT
     json_value(content, '$.Bairro') as Bairro
 FROM {{ stops }}
 where json_value(content, '$.PontoExistente') = 'SIM'
-and json_value(content, '$.idModalSmtr') = '22')
+and json_value(content, '$.idModalSmtr') = '22' or json_value(content, '$.idModalSmtr') = 'O'
+)
 select data_versao, AP, Bairro,
     sum(case when flag_vistoriada then 1 else 0 end) n_vistoridas,
     count(*) n_pontos

--- a/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
+++ b/smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada.sql
@@ -48,4 +48,4 @@ SELECT
 FROM {{ stops }} t
 where data_versao = (select max(data_versao) FROM {{ stops }})
 and json_value(content, '$.PontoExistente') = 'SIM'
-and json_value(content, '$.idModalSmtr') = '22'
+and json_value(content, '$.idModalSmtr') = '22' or json_value(content, '$.idModalSmtr') = 'O'


### PR DESCRIPTION
Resolve #38 

- Adiciona novos valores de `idModalSmtr` para as tabelas de flag_trajeto_correto, por usarem filtros explicitos. Essas mudanças foram realizadas pelos respectivos `defaults.yaml`
- Adiciona novo valor de `idModalSmtr` em `smtr/br_rj_riodejaneiro_sigmob/stops_desaninhada` e `smtr/br_rj_riodejaneiro_sigmob/agg_stops_vistoriadas`
- Modifica o scheduling das tabelas auxiliares do BRT, para executarem a cada 5 minutos