### PR TITLE
[WIP] Subsídio SPPO

### DIFF
--- a/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
@@ -15,7 +15,7 @@ shapes as (
     where 
         data_versao between (select min(data_versao) from gps) and (select max(data_versao) from gps)
     AND
-        id_modal_smtr in ('22', '20', 'O')
+        id_modal_smtr in ('22', 'O')
 ),
 status_viagem as (
     SELECT

--- a/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
@@ -1,0 +1,45 @@
+with gps as (
+    SELECT 
+        g.* except(longitude, latitude),
+        ST_GEOGPOINT(longitude, latitude) posicao_veiculo_geo,
+        d.data_versao_efetiva_shapes data_versao
+    FROM `rj-smtr.br_rj_riodejaneiro_veiculos.gps_sppo` g
+    JOIN `rj-smtr.br_rj_riodejaneiro_sigmob.data_versao_efetiva` d
+    ON g.data = d.data
+    WHERE g.data between '2022-02-15' and '2022-02-21'
+),
+shapes as (
+    SELECT 
+        *
+    FROM `rj-smtr.br_rj_riodejaneiro_sigmob.shapes_geom`
+    where 
+        data_versao between (select min(data_versao) from gps) and (select max(data_versao) from gps)
+    AND
+        id_modal_smtr in ('22', '20', 'O')
+),
+status_viagem as (
+    SELECT
+        id_veiculo,
+        timestamp_gps,
+        data,
+        servico,
+        distancia,
+        shape_id,
+        shape_distance,
+        CASE
+            WHEN ST_DWITHIN(posicao_veiculo_geo, start_pt, 200)
+            THEN 'start'
+            WHEN ST_DWITHIN(posicao_veiculo_geo, end_pt, 200)
+            THEN 'end'
+            WHEN flag_trajeto_correto_hist is true
+            THEN 'middle'
+        ELSE 'out'
+        END status_viagem
+    FROM gps g
+    JOIN shapes s
+    ON g.data_versao = s.data_versao
+    AND g.servico = s.linha_gtfs
+)
+SELECT *
+FROM status_viagem
+-- ORDER BY id_veiculo, servico, shape_id

--- a/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/aux_registros_status_viagem.sql
@@ -26,6 +26,7 @@ status_viagem as (
         distancia,
         shape_id,
         shape_distance,
+        flag_trajeto_correto_hist,
         CASE
             WHEN ST_DWITHIN(posicao_veiculo_geo, start_pt, 200)
             THEN 'start'

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
@@ -14,7 +14,7 @@ t as (
     FROM `rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.aux_registros_status_viagem`
     WHERE 
         data BETWEEN DATE('2022-02-01 10:10:10') AND DATE('2022-03-01 10:10:10')
-    -- ORDER BY shape_id, timestamp_gps
+    ORDER BY shape_id, timestamp_gps
 ),
 s AS (
     SELECT 

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
@@ -12,8 +12,6 @@ t as (
             ORDER BY id_veiculo, shape_id, timestamp_gps
             ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) = 'middleend' ends
     FROM `rj-smtr-dev.br_rj_riodejaneiro_viagens.aux_registros_status_viagem`
-    WHERE 
-        data BETWEEN DATE('2022-02-01 10:10:10') AND DATE('2022-03-01 10:10:10')
     ORDER BY shape_id, timestamp_gps
 ),
 s AS (

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
@@ -1,0 +1,75 @@
+-- get start/end of trips, detects vehicles coming in the buffer at each boundary point
+with 
+t as (
+    SELECT 
+        *,
+        string_agg(status_viagem,"") over (
+            PARTITION BY id_veiculo, shape_id
+            ORDER BY id_veiculo, shape_id, timestamp_gps
+            ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) = 'startmiddle' starts,
+        string_agg(status_viagem,"") over (
+            PARTITION BY id_veiculo, shape_id
+            ORDER BY id_veiculo, shape_id, timestamp_gps
+            ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) = 'middleend' ends
+    FROM `rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.aux_registros_status_viagem`
+    WHERE 
+        data BETWEEN DATE('2022-02-01 10:10:10') AND DATE('2022-03-01 10:10:10')
+    -- ORDER BY shape_id, timestamp_gps
+),
+s AS (
+    SELECT 
+        *,
+        CASE 
+            WHEN
+            string_agg(status_viagem,"") over (
+                PARTITION BY id_veiculo, shape_id
+                ORDER BY id_veiculo, shape_id, timestamp_gps
+                ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) = 'startend' 
+            THEN timestamp_gps 
+        END datetime_partida,
+        CASE 
+            WHEN string_agg(status_viagem,"") over (
+                PARTITION BY id_veiculo, shape_id
+                ORDER BY id_veiculo, shape_id, timestamp_gps
+                ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) = 'startend' 
+            THEN timestamp_gps
+        END datetime_chegada
+    FROM 
+        t
+    WHERE 
+        starts = true OR ends = true
+),
+w AS (
+    SELECT 
+        * EXCEPT(datetime_partida), 
+        lag(datetime_partida) over(
+        PARTITION BY id_veiculo, shape_id 
+        ORDER BY id_veiculo, shape_id, timestamp_gps) datetime_partida,
+    FROM s
+),
+realized_trips as (
+    SELECT 
+        *,
+        row_number() over (
+            partition by data, id_veiculo, servico, datetime_partida
+            order by tempo_gasto
+        ) rn
+    FROM (
+        SELECT 
+            data,
+            id_veiculo,
+            servico,
+            shape_id,
+            datetime_partida,
+            datetime_chegada,
+            1 AS tipo_trajeto,
+            datetime_diff(datetime_chegada, datetime_partida, minute) AS tempo_gasto, 
+            -- round(SAFE_DIVIDE(distancia/1000, datetime_diff(datetime_chegada, datetime_partida, minute)/60), 1) AS velocidade_trajeto,
+            -- STRUCT("maestro_sha" AS versao_maestro, "maestro_bq_sha" AS versao_maestro_bq) versao
+        FROM w
+        WHERE datetime_partida IS NOT NULL
+    ) 
+)
+SELECT r.* except(rn)
+FROM realized_trips r
+where rn = 1

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_realizadas.sql
@@ -11,7 +11,7 @@ t as (
             PARTITION BY id_veiculo, shape_id
             ORDER BY id_veiculo, shape_id, timestamp_gps
             ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) = 'middleend' ends
-    FROM `rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.aux_registros_status_viagem`
+    FROM `rj-smtr-dev.br_rj_riodejaneiro_viagens.aux_registros_status_viagem`
     WHERE 
         data BETWEEN DATE('2022-02-01 10:10:10') AND DATE('2022-03-01 10:10:10')
     ORDER BY shape_id, timestamp_gps

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
@@ -1,0 +1,91 @@
+with viagens as (
+    select 
+        *,
+        row_number() over (
+            partition by id_veiculo, servico, shape_id
+            order by datetime_partida
+        ) trip_number
+    from `rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.viagens_realizadas`
+),
+merge_trip as (
+    select 
+        s.*,
+        datetime_partida,
+        datetime_chegada,
+        -- trip_number
+        CASE 
+            WHEN 
+                timestamp_gps = datetime_partida
+                or
+                timestamp_gps = datetime_chegada
+            THEN
+                trip_number
+        END trip_number
+
+    from rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.aux_registros_status_viagem s
+    left join viagens v 
+    on s.data = v.data
+    and s.id_veiculo = v.id_veiculo
+    and (s.timestamp_gps = v.datetime_partida or s.timestamp_gps = v.datetime_chegada)
+    and s.shape_id = v.shape_id
+),
+classificacao as (
+    select 
+        * except(trip_number),
+        FIRST_VALUE(distancia/1000) over (
+            partition by id_veiculo, servico, shape_id, trip_number
+            order by timestamp_gps
+        ) d0,
+        CASE
+            WHEN
+                trip_number is not null
+            THEN 
+                trip_number
+            WHEN
+                (timestamp_gps >= LAST_VALUE(datetime_partida IGNORE NULLS) over (
+                        partition by id_veiculo, servico, shape_id
+                        order by timestamp_gps
+                        rows between unbounded preceding and current row
+                    )
+                and
+                timestamp_gps <= LAST_VALUE(datetime_chegada IGNORE NULLS) over (
+                        partition by id_veiculo, servico, shape_id
+                        order by timestamp_gps
+                        rows between  unbounded preceding and current row
+                    )
+                )
+            THEN 
+                LAST_VALUE(trip_number IGNORE NULLS) over (
+                        partition by id_veiculo, servico, shape_id
+                        order by timestamp_gps
+                        rows between unbounded preceding and current row
+                    )
+        END trip_number
+    FROM merge_trip mt
+),
+distancia_estimada as (
+    select 
+        data,
+        id_veiculo,
+        servico,
+        shape_id,
+        trip_number,
+        round(shape_distance/1000, 2) distancia_teorica,
+        round(sum(distancia)/1000,2)  distancia_km 
+    from classificacao 
+    where trip_number is not null
+    group by 1,2,3,4,5,6
+-- order by data, id_veiculo, servico, shape_id, timestamp_gps
+)
+select 
+    v.*,
+    distancia_teorica,
+    distancia_km,
+from viagens v
+join distancia_estimada d
+on v.data = d.data
+AND v.id_veiculo = d.id_veiculo
+AND v.servico = d.servico
+AND v.shape_id = d.shape_id
+and v.trip_number = d.trip_number
+order by data, id_veiculo, servico, shape_id, datetime_partida 

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
@@ -71,7 +71,9 @@ distancia_estimada as (
         shape_id,
         trip_number,
         round(shape_distance/1000, 2) distancia_teorica,
-        round(sum(distancia)/1000,2)  distancia_km 
+        round(sum(distancia)/1000,2)  distancia_km,
+        COUNT(CASE WHEN flag_trajeto_correto_hist is true then 1 end) flag_agg,
+        COUNT(timestamp_gps) n_registros, 
     from classificacao 
     where trip_number is not null
     group by 1,2,3,4,5,6
@@ -81,6 +83,7 @@ select
     v.*,
     distancia_teorica,
     distancia_km,
+    round(flag_agg/n_registros*100,2) perc_conformidade,
 from viagens v
 join distancia_estimada d
 on v.data = d.data

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
@@ -5,7 +5,7 @@ with viagens as (
             partition by id_veiculo, servico, shape_id
             order by datetime_partida
         ) trip_number
-    from `rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.viagens_realizadas`
+    from `rj-smtr-dev.br_rj_riodejaneiro_viagens.viagens_realizadas`
     -- order by datetime_partida
 ),
 merge_trip as (

--- a/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
+++ b/smtr/br_rj_riodejaneiro_viagens/viagens_validas.sql
@@ -22,7 +22,7 @@ merge_trip as (
             THEN
                 trip_number
         END trip_number
-    from rj-smtr-dev.br_rj_riodejaneiro_onibus_gps.aux_registros_status_viagem s
+    from rj-smtr-dev.br_rj_riodejaneiro_viagens.aux_registros_status_viagem s
     left join viagens v
     on s.data = v.data
     and s.id_veiculo = v.id_veiculo


### PR DESCRIPTION
Descrição breve:
Adiciona tabelas de cálculo de viagens realizadas e validação destas para os carros do SPPO, as viagens serão utilizadas para a contabilização de quilometragem do subsidio dado ao sistema.
Para viagens realizadas (completas) utilizamos a metodologia `start/end`, na qual detectamos como uma viagem completa o carro que tenha entrado num buffer de 200m em torno do ponto inicial do shape associado ao itinerário da viagem e, posteriormente, tenha passado pelo buffer de 200m em torno do ponto final. Esse passo é realizado em `aux_registros_status_viagem`.
Em `viagens_realizadas`, fazemos a lógica de detectar os pontos com `status_viagem` = `start` adjacentes a um `end` e recuperamos o tempo no qual a comunicação foi ali detectada para determinar o `datetime_partida` e o `datetime_chegada` de cada viagem.
Em `viagens_validas` levantamos e calculamos indicadores que permitem analisar o comportamento dos carros agregando por viagens, por enquanto temos implementado a velocidade média teórica (relativo ao tamanho do shape), a qual pode ser um bom filtro para viagens completas válidas especialmente no caso de BRT, que possui velocidades de via bem delimitadas. Já para o SPPO, utilizamos uma agregação por viagem para estimar a distância percorrida durante a realização do itinerário além da porcentagem de conformidade, calculada como a proporção entre o número de registros emitidos em área correta e o numero total de registros durante a viagem.